### PR TITLE
Update the png extension.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,5 +25,5 @@
     "storage"
   ],
   "icons": { "16": "icon16.png",
-            "128": "icon128.png" }
+            "128": "icon128.PNG" }
 }


### PR DESCRIPTION
Since it was capitalized, it wasn’t able to load. Resolve #1
Changing also the name file from .PNG to .png on the actual icon works aswell after my testing.